### PR TITLE
Add lcrc jenkins groovy script to DeveloperTools

### DIFF
--- a/ci/nwxJenkins.groovy
+++ b/ci/nwxJenkins.groovy
@@ -1,3 +1,5 @@
+//NWChemEx Jenkins Commands for Argonne LCRC Site
+
 def exportModules(buildModules){
 sh """
 set +x


### PR DESCRIPTION
Moving the LCRC Jenkins command script to a centralized location. 

Ready to go.