### PR TITLE
Change name of lmod module sets to unique ID

### DIFF
--- a/ci/Jenkins/Jenkinsfile.example
+++ b/ci/Jenkins/Jenkinsfile.example
@@ -3,7 +3,7 @@ def depends = ["CMakeBuild"] as String[]
 def commonModules = "cmake llvm "
 def buildModuleMatrix = [
     		   "GCC":(commonModules + "gcc/7.1.0"),
-		   "Intel":(commonModules + "gcc/7.1.0 intel-parallel-studio/cluster.2017.5-uxhpib5")
+		   "Intel":(commonModules + "gcc/7.1.0 intel-parallel-studio/cluster.2018.0-tpfbvga")
 		  ]
 def cmakeCommandMatrix = [
     		   "GCC":"-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++",

--- a/ci/Jenkins/nwxJenkins.groovy
+++ b/ci/Jenkins/nwxJenkins.groovy
@@ -1,9 +1,11 @@
+//BUILD_TAG is a unique build identifier provided by Jenkins
+
 def exportModules(buildModules){
 sh """
 set +x
 source /etc/profile
 module load ${buildModules}
-module save nwx-buildModules
+module save ${BUILD_TAG}
 """
 }
 
@@ -12,7 +14,7 @@ def compileRepo(repoName, doInstall, cmakeCommand){
     sh """
        set +x
 	source /etc/profile
-	module restore nwx-buildModules
+	module restore ${BUILD_TAG}
         buildTests="True"
         makeCommand=""
         if [ ${doInstall} == "True" ];then
@@ -33,7 +35,7 @@ def formatCode(){
     sh """
     set +x
     source /etc/profile
-    module restore nwx-buildModules
+    module restore ${BUILD_TAG}
     wget https://raw.githubusercontent.com/NWChemEx-Project/DeveloperTools/master/ci/lint/clang-format.in -O .clang-format
     find . -type f -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp | xargs clang-format -style=file -i -fallback-style=none
     rm .clang-format
@@ -70,7 +72,7 @@ def testRepo(){
     sh """
     set +x
     source /etc/profile
-    module restore nwx-buildModules
+    module restore ${BUILD_TAG}
     cd build && ctest
     """
 }


### PR DESCRIPTION
Previously, all module sets were called nwx-Modules. Module sets could be overwritten when running multiple CI jobs simultaneously, causing build errors. This PR changes the module set name to a unique ID for each job - specifically the $BUILD_TAG environmental variable provided by Jenkins.