### PR TITLE
Make ctest output more verbose

### DIFF
--- a/ci/Jenkins/nwxJenkins.groovy
+++ b/ci/Jenkins/nwxJenkins.groovy
@@ -73,7 +73,7 @@ def testRepo(){
     set +x
     source /etc/profile
     module restore ${BUILD_TAG}
-    cd build && ctest
+    cd build && ctest -VV
     """
 }
 


### PR DESCRIPTION
Adds `-vv` to ctest command to make test output more verbose.