### PR TITLE
Set default cc/cxx to GCC for compileRepo step

### DIFF
--- a/ci/Jenkins/nwxJenkins.groovy
+++ b/ci/Jenkins/nwxJenkins.groovy
@@ -21,7 +21,8 @@ def compileRepo(repoName, doInstall, cmakeCommand){
             buildTests="False"
             makeCommand="install"
         fi
-        git submodule update --init --recursive
+	CC=gcc
+	CXX=g++
         cmake -H. -Bbuild -DBUILD_TESTS=\${buildTests} \
                           -DCMAKE_INSTALL_PREFIX=${installRoot}\
                           -DCMAKE_PREFIX_PATH=${installRoot}\


### PR DESCRIPTION
Set CC/CXX env vars to GCC compilers in the compileRepo function. This aims to address the issue where Hunter is building HDF5 with Clang (according to CXX/CC vars left over from the formatting step) in spite of specifying gcc/intel compilers in the cmake command line.

The actual repo being tested will still be built with the compiler specified to cmake, overwriting CC/CXX.

Edit: In fact we need to use toolchains for this:
https://docs.hunter.sh/en/latest/overview/customization/toolchain-id.html