### PR TITLE
Set OpenMPI loopback btl for single-node communication

### DIFF
--- a/ci/Jenkins/nwxJenkins.groovy
+++ b/ci/Jenkins/nwxJenkins.groovy
@@ -81,6 +81,7 @@ def testRepo(){
        set +x
        source /etc/profile
        module restore ${BUILD_TAG}
+       export OMPI_MCA_btl=self
        cd build && ctest -VV
     """
 }


### PR DESCRIPTION
Adds an environmental variable to choose a loopback btl for our tests. This circumvents a bug where OpenMPI was choosing an Infiniband btl on a system where Infiniband is not configured.