### PR TITLE
update .gitignore and adds togglebutton dependencye

### DIFF
--- a/.github/workflows/scripts/get_dependencies.sh
+++ b/.github/workflows/scripts/get_dependencies.sh
@@ -210,6 +210,14 @@ get_sphinx() {
   ${PIP_COMMAND} install sphinx sphinx_rtd_theme
 }
 
+# Wraps installing the Togglebutton Sphinx Extension
+#
+# Usage:
+#   get_togglebutton
+get_togglebutton() {
+  ${PIP_COMMAND} install sphinx-togglebutton
+}
+
 ################################################################################
 #                               Main Script                                    #
 ################################################################################
@@ -250,6 +258,8 @@ for depend in "$@"; do
     get_scalapack
   elif [ "${depend}" = "sphinx" ]; then
     get_sphinx
+  elif [ "${depend}" = "togglebutton" ]; then
+    get_togglebutton
   else
     echo "Unrecognized dependency: ${depend}"
     exit 99

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ docs/build
 docs/doxyoutput
 docs/source/api
 *-build-*/
+_build/
 Debug/
 Release/
 


### PR DESCRIPTION
Togglebutton is a cool little sphinx extension that fixes #75. This PR updates `get_dependencies.sh` so it knows how to get it. Also I added the default VSCode documentation build directory, `_build`, to the `.gitignore`. This is r2g.