### PR TITLE
Fix for ParallelZone #22 PR, need to check on shared libs

### DIFF
--- a/cmake/nwx_python_mods.cmake
+++ b/cmake/nwx_python_mods.cmake
@@ -18,9 +18,16 @@
 #
 function(cppyy_make_python_package)
     #---------------------------------------------------------------------------
-    #-----------------------Make sure we have cppyy installed-------------------
+    #----------------------Check if Python bindings need to be build------------
     #---------------------------------------------------------------------------
     if (NOT BUILD_PYBINDINGS)
+        return()
+    endif()
+    #---------------------------------------------------------------------------
+    #----------------------Do not build bindings if shared_libs is off----------
+    #---------------------------------------------------------------------------
+    if (NOT BUILD_SHARED_LIBS)
+        message(WARNING, "BUILD_SHARED_LIBS is OFF, and Python needs shared libraries")
         return()
     endif()
     #---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses issue found by @keceli , where Python builds even when BUILD_SHARED_LIBS=OFF. Added a check and a warning message. 