### PR TITLE
Ignore __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ docs/venv/
 # This is where Jupyter/IPython store backup files
 .ipynb_checkpoints/
 
+# Byte-compiled Python
+__pycache__/
+
 # These are common build directory names
 build/
 docs/build


### PR DESCRIPTION
Ignore byte-compiled Python code, which is generated in `__pycache__` directories