### PR TITLE
Use ninja as CMake Generator

### DIFF
--- a/.github/workflows/scripts/build_and_test.sh
+++ b/.github/workflows/scripts/build_and_test.sh
@@ -53,7 +53,7 @@ echo "set(BUILD_TESTING ON)" > "${toolchain_file}"
 } >> "${toolchain_file}"
 
 #Step 2: Configure
-${cmake_command} -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"
+${cmake_command} -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"
 
 #Step 3: Compile
 ${cmake_command} --build build

--- a/.github/workflows/scripts/build_and_test.sh
+++ b/.github/workflows/scripts/build_and_test.sh
@@ -53,7 +53,12 @@ echo "set(BUILD_TESTING ON)" > "${toolchain_file}"
 } >> "${toolchain_file}"
 
 #Step 2: Configure
-${cmake_command} -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"
+if command -v ninja &> /dev/null
+then
+  ${cmake_command} -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"
+else
+  ${cmake_command} -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"
+fi
 
 #Step 3: Compile
 ${cmake_command} --build build

--- a/.github/workflows/scripts/get_dependencies.sh
+++ b/.github/workflows/scripts/get_dependencies.sh
@@ -246,7 +246,6 @@ for depend in "$@"; do
     get_clang_format
   elif [ "${depend}" = "cmake" ]; then
     get_cmake "${cmake_version}"
-    get_ninja
   elif [ "${depend}" = "cppyy" ]; then
     get_cppyy
   elif [ "${depend}" = "doxygen" ]; then
@@ -259,6 +258,8 @@ for depend in "$@"; do
     get_gcovr
   elif [ "${depend}" = "lapacke" ]; then
     get_lapacke
+  elif [ "${depend}" = "ninja" ]; then
+    get_ninja
   elif [ "${depend}" = "numpy" ]; then
     get_numpy
   elif [ "${depend}" = "openblas" ]; then

--- a/.github/workflows/scripts/get_dependencies.sh
+++ b/.github/workflows/scripts/get_dependencies.sh
@@ -198,6 +198,16 @@ get_scalapack() {
   ${APT_GET_COMMAND} install libscalapack-openmpi-dev
 }
 
+# Wraps installing ninja
+#
+# Usage:
+#   get_ninja
+#
+get_ninja() {
+  ${APT_COMMAND} update
+  ${APT_GET_COMMAND} install ninja-build
+}
+
 # Wraps installing Sphinx and the ReadTheDocs Theme
 #
 # Usage:
@@ -236,6 +246,7 @@ for depend in "$@"; do
     get_clang_format
   elif [ "${depend}" = "cmake" ]; then
     get_cmake "${cmake_version}"
+    get_ninja
   elif [ "${depend}" = "cppyy" ]; then
     get_cppyy
   elif [ "${depend}" = "doxygen" ]; then

--- a/.github/workflows/scripts/get_dependencies.sh
+++ b/.github/workflows/scripts/get_dependencies.sh
@@ -161,6 +161,16 @@ get_lapacke() {
   ${APT_GET_COMMAND} install liblapacke liblapacke-dev
 }
 
+# Wraps installing ninja
+#
+# Usage:
+#   get_ninja
+#
+get_ninja() {
+  ${APT_COMMAND} update
+  ${APT_GET_COMMAND} install ninja-build
+}
+
 # Wraps installing numpy
 #
 # Usage:
@@ -196,16 +206,6 @@ get_openmpi() {
 get_scalapack() {
   ${APT_COMMAND} update
   ${APT_GET_COMMAND} install libscalapack-openmpi-dev
-}
-
-# Wraps installing ninja
-#
-# Usage:
-#   get_ninja
-#
-get_ninja() {
-  ${APT_COMMAND} update
-  ${APT_GET_COMMAND} install ninja-build
 }
 
 # Wraps installing Sphinx and the ReadTheDocs Theme


### PR DESCRIPTION
I get around 20% faster build times with ninja. If nobody has any objections or bad experience with it, I suggest switching to ninja to save CI times.

It will be installed together with cmake in the [current setup](https://github.com/NWChemEx-Project/DeveloperTools/blob/a17c558724f741c525cb4f41c13d380712917366/.github/workflows/scripts/get_dependencies.sh#L249) to avoid updating each repo by adding ninja as a dependency. If that is not ideal, I can do the updates.