### PR TITLE
Fix ninja check

### DIFF
--- a/.github/workflows/scripts/build_and_test.sh
+++ b/.github/workflows/scripts/build_and_test.sh
@@ -53,7 +53,7 @@ echo "set(BUILD_TESTING ON)" > "${toolchain_file}"
 } >> "${toolchain_file}"
 
 #Step 2: Configure
-if command -v ninja &> /dev/null
+if which ninja >/dev/null; then
 then
   ${cmake_command} -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"
 else


### PR DESCRIPTION
While `command` check is recommended as being posix compliant on [SO](https://stackoverflow.com/a/677212/2096243), it gave a false true on github CI. `which` check works correctly.