### PR TITLE
Revert "Fix ninja check"

### DIFF
--- a/.github/workflows/scripts/build_and_test.sh
+++ b/.github/workflows/scripts/build_and_test.sh
@@ -53,7 +53,7 @@ echo "set(BUILD_TESTING ON)" > "${toolchain_file}"
 } >> "${toolchain_file}"
 
 #Step 2: Configure
-if which ninja >/dev/null; then
+if command -v ninja &> /dev/null
 then
   ${cmake_command} -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"
 else


### PR DESCRIPTION
Reverts NWChemEx-Project/DeveloperTools#121.

CI's not working with Ninja, in an attempt to restore it to a working state I'm reverting the Ninja changes. The Ninja changes are welcome to be added to CI once they've been worked out.